### PR TITLE
[WineHQReportMode - Phase 0] Refactor: Add multi wineprefix capabilities 

### DIFF
--- a/cmd/vinegar/binary.go
+++ b/cmd/vinegar/binary.go
@@ -15,7 +15,7 @@ import (
 	"github.com/vinegarhq/vinegar/wine/dxvk"
 )
 
-func SetupBinary(ver roblox.Version, dir string) {
+func SetupBinary(pfx *wine.Prefix, ver roblox.Version, dir string) {
 	if err := dirs.Mkdirs(dir, dirs.Downloads); err != nil {
 		log.Fatal(err)
 	}
@@ -33,15 +33,15 @@ func SetupBinary(ver roblox.Version, dir string) {
 		log.Fatal(err)
 	}
 
-	if err := state.SaveManifest(&manifest); err != nil {
+	if err := state.SaveManifest(pfx, &manifest); err != nil {
 		log.Fatal(err)
 	}
 
-	if err := state.CleanPackages(); err != nil {
+	if err := state.CleanPackages(pfx); err != nil {
 		log.Fatal(err)
 	}
 
-	if err := state.CleanVersions(); err != nil {
+	if err := state.CleanVersions(pfx); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -58,7 +58,7 @@ func Binary(bt roblox.BinaryType, cfg *config.Config, pfx *wine.Prefix, args ...
 		appCfg = cfg.Studio
 	}
 
-	dxvkVersion, err := state.DxvkVersion()
+	dxvkVersion, err := state.DxvkVersion(pfx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func Binary(bt roblox.BinaryType, cfg *config.Config, pfx *wine.Prefix, args ...
 				log.Fatal(err)
 			}
 
-			if err := state.SaveDxvk(cfg.DxvkVersion); err != nil {
+			if err := state.SaveDxvk(pfx, cfg.DxvkVersion); err != nil {
 				log.Fatal(err)
 			}
 		}
@@ -91,7 +91,7 @@ func Binary(bt roblox.BinaryType, cfg *config.Config, pfx *wine.Prefix, args ...
 			log.Fatal(err)
 		}
 
-		if err := state.SaveDxvk(""); err != nil {
+		if err := state.SaveDxvk(pfx, ""); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -114,12 +114,12 @@ func Binary(bt roblox.BinaryType, cfg *config.Config, pfx *wine.Prefix, args ...
 		}
 	}
 
-	verDir := filepath.Join(dirs.Versions, ver.GUID)
+	verDir := filepath.Join(dirs.GetVersionsPath(pfx), ver.GUID)
 
 	_, err = os.Stat(filepath.Join(verDir, "AppSettings.xml"))
 	if err != nil {
 		log.Printf("Updating/Installing %s", name)
-		SetupBinary(ver, verDir)
+		SetupBinary(pfx, ver, verDir)
 	} else {
 		log.Printf("%s is up to date (%s)", name, ver.GUID)
 	}

--- a/cmd/vinegar/vinegar.go
+++ b/cmd/vinegar/vinegar.go
@@ -57,7 +57,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		pfx := wine.New(dirs.Prefix)
+		pfx := wine.New(dirs.GetPrefixPath(""))
 		pfx.Interrupt()
 
 		if err := pfx.Setup(); err != nil {
@@ -98,7 +98,9 @@ func main() {
 }
 
 func Uninstall() {
-	vers, err := state.Versions()
+	pfx := wine.New(dirs.GetPrefixPath(""))
+
+	vers, err := state.Versions(&pfx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -106,21 +108,23 @@ func Uninstall() {
 	for _, ver := range vers {
 		log.Println("Removing version directory", ver)
 
-		err = os.RemoveAll(filepath.Join(dirs.Versions, ver))
+		err = os.RemoveAll(filepath.Join(dirs.GetVersionsPath(&pfx), ver))
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
 
-	err = state.ClearApplications()
+	err = state.ClearApplications(&pfx)
 	if err != nil {
 		log.Fatal(err)
 	}
 }
 
 func Delete() {
+	var prefix = dirs.GetPrefixPath("")
+
 	log.Println("Deleting Wineprefix")
-	if err := os.RemoveAll(dirs.Prefix); err != nil {
+	if err := os.RemoveAll(prefix); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/internal/config/state/cleaners.go
+++ b/internal/config/state/cleaners.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/vinegarhq/vinegar/internal/dirs"
 	"github.com/vinegarhq/vinegar/util"
+	"github.com/vinegarhq/vinegar/wine"
 )
 
-func CleanPackages() error {
-	pkgs, err := Packages()
+func CleanPackages(pfx *wine.Prefix) error {
+	pkgs, err := Packages(pfx)
 	if err != nil {
 		return err
 	}
@@ -23,16 +24,18 @@ func CleanPackages() error {
 	})
 }
 
-func CleanVersions() error {
-	vers, err := Versions()
+func CleanVersions(pfx *wine.Prefix) error {
+	var versionsDir = dirs.GetVersionsPath(pfx)
+
+	vers, err := Versions(pfx)
 	if err != nil {
 		return err
 	}
 
 	log.Println("Checking for unused version directories")
 
-	return util.WalkDirExcluded(dirs.Versions, vers, func(path string) error {
+	return util.WalkDirExcluded(versionsDir, vers, func(path string) error {
 		log.Printf("Removing unused version directory %s", path)
-		return os.RemoveAll(filepath.Join(dirs.Versions, path))
+		return os.RemoveAll(filepath.Join(versionsDir, path))
 	})
 }

--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -5,19 +5,39 @@ import (
 	"path/filepath"
 
 	"github.com/adrg/xdg"
+	"github.com/vinegarhq/vinegar/wine"
 )
 
 var (
-	Cache      = filepath.Join(xdg.CacheHome, "vinegar")
-	Config     = filepath.Join(xdg.ConfigHome, "vinegar")
-	Data       = filepath.Join(xdg.DataHome, "vinegar")
-	Overlay    = filepath.Join(Config, "overlay")
-	Downloads  = filepath.Join(Cache, "downloads")
-	Logs       = filepath.Join(Cache, "logs")
-	Prefix     = filepath.Join(Data, "prefix")
-	PrefixData = filepath.Join(Prefix, "vinegar")
-	Versions   = filepath.Join(PrefixData, "versions")
+	Cache     = filepath.Join(xdg.CacheHome, "vinegar")
+	Config    = filepath.Join(xdg.ConfigHome, "vinegar")
+	Data      = filepath.Join(xdg.DataHome, "vinegar")
+	Overlay   = filepath.Join(Config, "overlay")
+	Downloads = filepath.Join(Cache, "downloads")
+	Logs      = filepath.Join(Cache, "logs")
 )
+
+var (
+	Prefix_Name         = "prefix"
+	PrefixData_Relative = "vinegar"
+	Versions_Relative   = filepath.Join(PrefixData_Relative, "versions")
+)
+
+func GetPrefixPath(name string) string {
+	if name != "" {
+		return filepath.Join(Data, Prefix_Name+"-"+name)
+	} else {
+		return filepath.Join(Data, Prefix_Name)
+	}
+}
+
+func GetPrefixData(pfx *wine.Prefix) string {
+	return filepath.Join(pfx.Dir, PrefixData_Relative)
+}
+
+func GetVersionsPath(pfx *wine.Prefix) string {
+	return filepath.Join(pfx.Dir, Versions_Relative)
+}
 
 func Mkdirs(dirs ...string) error {
 	for _, dir := range dirs {


### PR DESCRIPTION
Although a decent chunk of the Vinegar codebase already supports multiple wineprefixes, a few pieces like State were missing support. This PR adds that support to the codebase, allowing multiple wineprefixes to independently exist. It's a requirement for the proposed WineHQReportMode functionality at #156 work.

Please note: This functionality is not intended to be used to separate Roblox Player and Roblox Studio. These prefixes are fully independent and don't share anything, including cached downloads. While that functionality is technically feasible, I decided to not add it since it's not required for the purpose of WineHQReportMode.

This PR adds no sort of user-facing interface to change prefixes, nor creates additional ones. It simply makes the infrastructure changes necessary for allowing WineHQReportMode to switch to an independent prefix when enabled. 

The main change was done to `dirs.go`:

- dirs.go no longer provides direct paths for the wineprefix or any of its contents. Instead, it now provides new functions which return the right paths. 
- The default prefix continues to have the same location (no breaking changes); it can be requested by passing an empty name string. 
- Other prefixes follow this naming scheme: `prefix-(prefix-name)`; for example:  `prefix-winehqreportmode`
```
var (
	Prefix_Name         = "prefix"
	PrefixData_Relative = "vinegar"
	Versions_Relative   = filepath.Join(PrefixData_Relative, "versions")
)

func GetPrefixPath(name string) string {
	if name != "" {
		return filepath.Join(Data, Prefix_Name+"-"+name)
	} else {
		return filepath.Join(Data, Prefix_Name)
	}
}

func GetPrefixData(pfx *wine.Prefix) string {
	return filepath.Join(pfx.Dir, PrefixData_Relative)
}

func GetVersionsPath(pfx *wine.Prefix) string {
	return filepath.Join(pfx.Dir, Versions_Relative)
}
```
Some API changes had to be made to `state.go` and `cleaners.go` to account for multiple prefixes.
- There's no longer any reliance on static prefix paths.
- Every function which used to interact with prefix paths now has an additional `*wine.Prefix` object parameter. This is what's used to define which prefix will have its state changed.
- All existing file structures remain the same; no breaking changes.

There were minor updates done to `binary.go` and `vinegar.go` to account for the changes above.
- All code which made calls to `prefix.go` remains valid and requires no changes.
- Other calls have the extra prefix parameter added to them.
- Prefix object is no longer created with the Prefix path, since it's no longer defined. The new path is defined by `dirs.GetPrefixPath("")`, which returns the same path as previously.
This means that there's no actual user-facing way of creating or switching prefixes. This change is just internal and fully transparent to the outside world.

I've tested all Vinegar functionality I could think of and did not spot any regressions caused by this PR.