### PR TITLE
Added config option to override wineroot

### DIFF
--- a/cmd/vinegar/vinegar.go
+++ b/cmd/vinegar/vinegar.go
@@ -51,7 +51,20 @@ func main() {
 	// but they require a wineprefix, hence wineroot of configuration is required.
 	case "player", "studio", "exec", "kill", "install-webview2":
 		pfxKilled := false
-		cfg, err := config.Load(*configPath)
+
+		var cfg config.Config
+		var err error
+
+		switch cmd {
+
+		case "player":
+			cfg, err = config.LoadForTarget(*configPath,"P")
+		case "studio":
+			cfg, err = config.LoadForTarget(*configPath,"S")
+		default:
+			cfg, err = config.Load(*configPath)
+		}
+
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
When running player or studio, vinegar will check if there is a wineroot field underneath the respective app.
Global wineroot would be used for all other apps, or if an override isn't found for player/studio.
This allows people to use the latest wine version for studio (for stability) while keeping the player running on a downgraded version (as it currently can't run on newer versions).