### PR TITLE
Remove Vinegar branding from desktop entries

### DIFF
--- a/desktop/roblox-app.desktop.in
+++ b/desktop/roblox-app.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=Roblox App (Vinegar)
+Name=Roblox App
 Icon=$FLATPAK.player
 Exec=vinegar player -app
 Terminal=false

--- a/desktop/roblox-player.desktop.in
+++ b/desktop/roblox-player.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=Roblox Player (Vinegar)
+Name=Roblox Player
 NoDisplay=true
 Icon=$FLATPAK.player
 Exec=vinegar player %u

--- a/desktop/roblox-studio.desktop.in
+++ b/desktop/roblox-studio.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=Roblox Studio (Vinegar)
+Name=Roblox Studio
 Icon=$FLATPAK.studio
 Exec=vinegar studio %u
 Terminal=false


### PR DESCRIPTION
We now have the loading screen to establish Vinegar's branding, so no need to clutter the desktop entries unnecessarily anymore.