### PR TITLE
Set env OBS_VKCAPTURE by default for player

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -116,6 +116,9 @@ func Default() Config {
 			FFlags: roblox.FFlags{
 				"DFIntTaskSchedulerTargetFps": 640,
 			},
+			Env: Environment{
+				"OBS_VKCAPTURE": "1",
+			},
 		},
 		Studio: Binary{
 			Dxvk: true,


### PR DESCRIPTION
OBS_VKCAPTURE allows OBS to capture Roblox Player's vulkan buffer directly, bypassing window decorations and providing lower latencies.

This default is player-only for now, as OBS will get confused with studio and capture plugin windows instead of the actual viewport. Studio captures also flicker, probably due to limitations with the childwindow patch.