### PR TITLE
Show git head sha in sysinfo output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,10 @@ FLATPAK = io.github.vinegarhq.Vinegar
 
 GO = go
 GO_LDFLAGS = -s -w
+GIT_HEAD = $(shell git log -1 --pretty=format:"%H")
 
 VINEGAR_ICONPATH = $(ICONPREFIX)/64x64/apps/$(FLATPAK).png
-VINEGAR_LDFLAGS = $(GO_LDFLAGS) -X main.BinPrefix=$(BINPREFIX) -X main.Version=$(VERSION)
+VINEGAR_LDFLAGS = $(GO_LDFLAGS) -X main.BinPrefix=$(BINPREFIX) -X main.Version=$(VERSION) -X main.GitHead=$(GIT_HEAD)
 VINEGAR_GOFLAGS = --tags nowayland,novulkan
 
 all: vinegar robloxmutexer.exe

--- a/cmd/vinegar/vinegar.go
+++ b/cmd/vinegar/vinegar.go
@@ -22,6 +22,7 @@ import (
 var (
 	BinPrefix string
 	Version   string
+	GitHead   string
 )
 
 func usage() {
@@ -130,6 +131,12 @@ func Delete() {
 }
 
 func Sysinfo(pfx *wine.Prefix) {
+	fmtHead := GitHead
+
+	if fmtHead == "" {
+		fmtHead = "N/A"
+	}
+
 	cmd := pfx.Wine("--version")
 	cmd.Stdout = nil // required for Output()
 	ver, err := cmd.Output()
@@ -137,14 +144,14 @@ func Sysinfo(pfx *wine.Prefix) {
 		log.Fatal(err)
 	}
 
-	info := `* Vinegar: %s
+	info := `* Vinegar: %s (%s)
 * Distro: %s
 * Processor: %s
   * Supports AVX: %t
 * Kernel: %s
 * Wine: %s`
 
-	fmt.Printf(info, Version, sysinfo.Distro, sysinfo.CPU, sysinfo.HasAVX, sysinfo.Kernel, ver)
+	fmt.Printf(info, Version, fmtHead, sysinfo.Distro, sysinfo.CPU, sysinfo.HasAVX, sysinfo.Kernel, ver)
 	if sysinfo.InFlatpak {
 		fmt.Println("* Flatpak: [x]")
 	}


### PR DESCRIPTION
Currently, we have no way of telling apart users which are using packaged Vinegar from users which are building vinegar from source. Any potential reports they make will apply to a specific point of our master branch instead of stable releases.

This PR fixes that issue by building Vinegar with the current git head's sha1 and displaying it as part of sysinfo's output, allowing us to identify if the user isn't on a stable release and at what precise point of history their Vinegar binary was built on.

![imagem](https://github.com/vinegarhq/vinegar/assets/55360900/3ad33a10-3848-4465-8d4f-fc872cbb26b4)

![imagem](https://github.com/vinegarhq/vinegar/assets/55360900/b1f9ccf1-9bc8-4781-a5b7-5c0707295138)
If the sha can't be fetched during build time (for example, if git isn't installed or the user isn't building from a git repository), then N/A is shown.


  