### PR TITLE
sysinfo: check if cpu has split lock detection flag

### DIFF
--- a/cmd/vinegar/vinegar.go
+++ b/cmd/vinegar/vinegar.go
@@ -150,10 +150,11 @@ func Sysinfo(pfx *wine.Prefix) {
 * Distro: %s
 * Processor: %s
   * Supports AVX: %t
+  * Supports split lock detection: %t
 * Kernel: %s
 * Wine: %s`
 
-	fmt.Printf(info, Version, revision, sysinfo.Distro, sysinfo.CPU, sysinfo.HasAVX, sysinfo.Kernel, ver)
+	fmt.Printf(info, Version, revision, sysinfo.Distro, sysinfo.CPU, sysinfo.HasAVX, sysinfo.HasSplitLockDetect, sysinfo.Kernel, ver)
 	if sysinfo.InFlatpak {
 		fmt.Println("* Flatpak: [x]")
 	}

--- a/sysinfo/cpu.go
+++ b/sysinfo/cpu.go
@@ -6,15 +6,19 @@ import (
 	"bufio"
 	"os"
 	"regexp"
+	"strings"
 )
 
-func cpuModel() string {
+func cpuModel() (string, bool) {
 	column := regexp.MustCompile("\t+: ")
 
 	f, _ := os.Open("/proc/cpuinfo")
 	defer f.Close()
 
 	s := bufio.NewScanner(f)
+
+	n := "unknown cpu"
+	l := false
 
 	for s.Scan() {
 		sl := column.Split(s.Text(), 2)
@@ -24,9 +28,15 @@ func cpuModel() string {
 
 		// pfft, who needs multiple cpus? just return if we got all we need
 		if sl[0] == "model name" {
-			return sl[1]
+			n = sl[1]
 		}
+
+		if sl[0] == "flags" {
+			l = strings.Contains(sl[1], "split_lock_detect")
+			break
+		}
+
 	}
 
-	return "unknown cpu"
+	return n, l
 }

--- a/sysinfo/sysinfo.go
+++ b/sysinfo/sysinfo.go
@@ -9,17 +9,18 @@ import (
 )
 
 var (
-	Kernel    string
-	CPU       string
-	Cards     []Card
-	Distro    string
-	HasAVX    = cpu.X86.HasAVX
-	InFlatpak bool
+	Kernel             string
+	CPU                string
+	Cards              []Card
+	Distro             string
+	HasAVX             = cpu.X86.HasAVX
+	HasSplitLockDetect bool
+	InFlatpak          bool
 )
 
 func init() {
 	Kernel = getKernel()
-	CPU = cpuModel()
+	CPU, HasSplitLockDetect = cpuModel()
 	Cards = getCards()
 	Distro = getDistro()
 


### PR DESCRIPTION
Check if the cpu has split lock detection, then output accordingly with the sysinfo command. This helps users diagnose if their machine is affected by the split lock trap issue. 

Go's cpu package does not expose this "flag" (seems to not actually be a real cpu flag, just something made up by the linux kernel), so it must be read directly from cpuinfo. 

Documentation will be updated accordingly.

Note: Unsure if "Supports split lock detection" or "Has split lock detection" is better.  Let me know.