### PR TITLE
Update Flathub badge image to new Flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An open-source, minimal, configurable, fast bootstrapper for running Roblox on L
 [version]:     https://github.com/vinegarhq/vinegar/releases/latest
 [version_img]: https://img.shields.io/github/v/release/vinegarhq/vinegar?style=flat-square&display_name=tag
 [flathub]:     https://flathub.org/apps/details/org.vinegarhq.Vinegar
-[flathub_img]: https://img.shields.io/flathub/downloads/io.github.vinegarhq.Vinegar?style=flat-square
+[flathub_img]: https://img.shields.io/flathub/downloads/org.vinegarhq.Vinegar?style=flat-square
 [goreportcard]:     https://goreportcard.com/report/github.com/vinegarhq/vinegar
 [goreportcard_img]: https://goreportcard.com/badge/github.com/vinegarhq/vinegar?style=flat-square
 [discord]:     https://discord.gg/dzdzZ6Pps2


### PR DESCRIPTION
It's still pointing to io.github.vinegarhq.Vinegar instead of org.vinegarhq.Vinegar, so the installs counter is wrong.