### PR TITLE
Do not show wine's prefix init/update window

### DIFF
--- a/wine/cmd.go
+++ b/wine/cmd.go
@@ -38,6 +38,16 @@ func (p *Prefix) Command(name string, arg ...string) *Cmd {
 	}
 }
 
+// Headless prevents command from showing windows
+func (c *Cmd) Headless() *Cmd {
+	c.Env = append(c.Environ(),
+		"DISPLAY=",
+		"WAYLAND_DISPLAY=",
+	)
+
+	return c
+}
+
 // Refer to [exec.Cmd.Run].
 func (c *Cmd) Run() error {
 	if err := c.Start(); err != nil {
@@ -45,7 +55,6 @@ func (c *Cmd) Run() error {
 	}
 	return c.Wait()
 }
-
 // Refer to [exec.Cmd.Start] and [Command].
 func (c *Cmd) Start() error {
 	if c.Process != nil {

--- a/wine/cmd.go
+++ b/wine/cmd.go
@@ -44,7 +44,6 @@ func (c *Cmd) Headless() *Cmd {
 		"DISPLAY=",
 		"WAYLAND_DISPLAY=",
 	)
-
 	return c
 }
 

--- a/wine/cmd.go
+++ b/wine/cmd.go
@@ -43,6 +43,7 @@ func (c *Cmd) Headless() *Cmd {
 	c.Env = append(c.Environ(),
 		"DISPLAY=",
 		"WAYLAND_DISPLAY=",
+		"WINEDEBUG=fixme-all,-winediag,-systray,-ole,-winediag,-ntoskrnl", //Suppress window-related errors
 	)
 	return c
 }

--- a/wine/registry.go
+++ b/wine/registry.go
@@ -24,5 +24,5 @@ func (p *Prefix) RegistryAdd(key, value string, rtype RegistryType, data string)
 		return errors.New("no registry key given")
 	}
 
-	return p.Wine("reg", "add", key, "/v", value, "/t", string(rtype), "/d", data, "/f").Run()
+	return p.Wine("reg", "add", key, "/v", value, "/t", string(rtype), "/d", data, "/f").Headless().Run()
 }

--- a/wine/wine.go
+++ b/wine/wine.go
@@ -120,14 +120,14 @@ func (p *Prefix) Kill() error {
 	return p.Wine("wineboot", "-k").Run()
 }
 
-// Init preforms initialization for first Wine instance.
+// Init performs initialization for first Wine instance.
 func (p *Prefix) Init() error {
-	return p.Wine("wineboot", "-i").Run()
+	return p.Wine("wineboot", "-i").Headless().Run()
 }
 
 // Update updates the wineprefix directory.
 func (p *Prefix) Update() error {
-	return p.Wine("wineboot", "-u").Run()
+	return p.Wine("wineboot", "-u").Headless().Run()
 }
 
 // Version returns the wineprefix's Wine version.


### PR DESCRIPTION
wineboot shows an annoying window whenever it inits or updates a prefix. Prevent that by setting DISPLAY and WAYLAND_DISPLAY envs to nothing. 

this PR also fixes a minor spelling error with a related comment ;)