### PR TITLE
add dxvk-patch-1

### DIFF
--- a/dxvk/dxvk.go
+++ b/dxvk/dxvk.go
@@ -36,6 +36,12 @@ func Remove(pfx *wine.Prefix) error {
 
 			slog.Info("Removing DXVK overriden Wine DLL", "path", p)
 
+                        // Checks to see if the given file exists, if not, skips it and continues removal process
+                        if _, err := os.Stat(p); os.IsNotExist(err) {
+                                slog.Info("File does not exist, skipping", "path", p)
+                                continue
+                        }
+
 			if err := os.Remove(p); err != nil {
 				return err
 			}


### PR DESCRIPTION
Added a check under `dxvk/dxvk.go:Remove()` to first see if a DLL exists, if not, skip it and move onto the next file. Without this check, vinegar may return: 

> ERR failed to setup roblox: setup dxvk 2.3: remove dxvk: remove ~/.var/app/org.vinegarhq.Vinegar/data/vinegar/prefixes/studio/drive_c/windows/syswow64/d3d9.dll: no such file or directory 

on startup and crash. 