### PR TITLE
Fix Sober Compatibility issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,6 @@ uninstall:
 	rm -f $(DESTDIR)$(ICONPREFIX)/128x128/apps/org.vinegarhq.Vinegar.studio.png
 
 mime:
-	xdg-mime default org.vinegarhq.Vinegar.player.desktop x-scheme-handler/roblox-player
-	xdg-mime default org.vinegarhq.Vinegar.player.desktop x-scheme-handler/roblox
 	xdg-mime default org.vinegarhq.Vinegar.studio.desktop x-scheme-handler/roblox-studio
 	xdg-mime default org.vinegarhq.Vinegar.studio.desktop x-scheme-handler/roblox-studio-auth
 	xdg-mime default org.vinegarhq.Vinegar.studio.desktop application/x-roblox-rbxl


### PR DESCRIPTION
Make it so by default the outdated Roblox Wine player doesn't get set as the default app for roblox-player, this will prevent it from being launched instead of Sober.