### PR TITLE
Crowbar fix for #454

### DIFF
--- a/cmd/vinegar/binary_setup.go
+++ b/cmd/vinegar/binary_setup.go
@@ -182,7 +182,12 @@ func (b *Binary) SetupPackages() error {
 			src := filepath.Join(dirs.Downloads, p.Checksum)
 			dst, ok := pd[p.Name]
 			if !ok {
-				return fmt.Errorf("unhandled package: %s", p.Name)
+				slog.Warn("A package was not handled - this likely needs to be fixed!")
+				fmt.Errorf("unhandled package: %s", p.Name) // TODO(i3vie): This is a HUGE crowbar fix
+														   // that will probably bite someone in the
+														   // ass in the future, but it gets Studio
+														   // working for now.
+														   // See issue #454.
 			}
 
 			defer func() {


### PR DESCRIPTION
Now, this issue does close #454 and get Studio to run again, although it's admittedly not a great fix. 
See:
```
// TODO(i3vie): This is a HUGE crowbar fix
// that will probably bite someone in the
 // ass in the future, but it gets Studio
// working for now.
```
This just ignores unhandled packages and does seem to get Studio to work again, and as far as I can tell from a quick test, doesn't seem to cause any major problems. Packages probably do need to be handled, but this should function as a workaround.