### PR TITLE
Replace WINEESYNC environment variable with WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,7 +114,7 @@ func Default() *Config {
 			DiscordRPC: true,
 			FFlags:     make(rbxbin.FFlags),
 			Env: map[string]string{
-				"WINEESYNC": "1",
+				"WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS": "--use-angle=gl",
 			},
 		},
 	}

--- a/internal/config/save_test.go
+++ b/internal/config/save_test.go
@@ -23,7 +23,7 @@ func TestConfigEncode(t *testing.T) {
 	cfg.Studio.WebView = ""
 	cfg.Studio.FFlags["DFIntFoo"] = 960
 	cfg.Studio.Env["FOO"] = "1"
-	delete(cfg.Env, "WINEESYNC") // It's only temporary.
+	delete(cfg.Env, "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS") // It's only temporary.
 
 	if err := cfg.Encode(buf); err != nil {
 		t.Error(err)


### PR DESCRIPTION
This replaces the default environment variable `WINEESYNC` (which does nothing, considering that our Wine builds aren't even build with Esync support), with `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS`, used for passing arguments to WebView2. The added argument enables ANGLE's OpenGL backend for WebView2, useful for working around any issues related to WineD3D and DXVK.

I was originally going to make Vulkan the ANGLE backend, but it didn't work as well as the OpenGL one.