### PR TITLE
Add additional WebView2 argument that fixes input delay

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,7 +114,7 @@ func Default() *Config {
 			DiscordRPC: true,
 			FFlags:     make(rbxbin.FFlags),
 			Env: map[string]string{
-				"WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS": "--use-angle=gl",
+				"WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS": "--use-angle=gl --in-process-gpu",
 			},
 		},
 	}


### PR DESCRIPTION
This adds `--in-process-gpu` as an additional default argument for WebView2.

Fixes issues related to input delay within WebView2 rendered content and flickering when resizing the toolbox.