### PR TITLE
Remove useless environment variables

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,8 +161,6 @@ func (c *Config) Prefix() (*wine.Prefix, error) {
 		env["DXVK_LOG_PATH"] = "none"
 	}
 	env["VK_LOADER_LAYERS_ENABLE"] = "VK_LAYER_VINEGAR_VinegarLayer"
-	env["MESA_GL_VERSION_OVERRIDE"] = "4.4"
-	env["__GL_THREADED_OPTIMIZATIONS"] = "1"
 
 	for k, v := range env {
 		pfx.Env = append(pfx.Env, k+"="+v)


### PR DESCRIPTION
`__GL_THREADED_OPTIMIZATIONS=1` was causing a regression with WineD3D+Nvidia+Flatpak, where Roblox Studio would either refuse to launch or give an error popup about the GPU not meeting the minimum requirements.

`MESA_GL_VERSION_OVERRIDE=4.4` was kept for legacy hardware, but is automatically set when launching Studio, no matter what. It would be better if Vinegar automatically detected the maximum supported GL version instead of having this override set by default.

Solves https://github.com/vinegarhq/vinegar/issues/679.