### PR TITLE
Update default WebView2 version to 143.0.3650.96

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,7 +43,7 @@ func (v DxvkVersion) String() string {
 }
 
 type Studio struct {
-	WebView  string `toml:"webview" group:"" row:"Disable if nonfunctional,entry,WebView2 Version,141.0.3537.71" title:"Web Pages"`
+	WebView  string `toml:"webview" group:"" row:"Disable if nonfunctional,entry,WebView2 Version,143.0.3650.96" title:"Web Pages"`
 	WineRoot string `toml:"wineroot" group:"" row:"Installation Directory,path"`
 	Launcher string `toml:"launcher" group:"" row:"Launcher Command (ex. gamescope)"`
 


### PR DESCRIPTION
Version 143.0.3650.96 works under Wine so I don't see a reason not to update to it.