### PR TITLE
Fix Discord RPC

### DIFF
--- a/internal/studiorpc/studiorpc.go
+++ b/internal/studiorpc/studiorpc.go
@@ -46,13 +46,13 @@ func (s *StudioRPC) Handle(line string) error {
 }
 
 func (s *StudioRPC) handleOpen(line string) error {
-	const entry = "[FLog::StudioKeyEvents] open place (identifier = "
+	const entry = "[FLog::CloseDataModel] Setting place ID "
 	if !strings.HasPrefix(line, entry) {
 		return nil
 	}
 
-	// open place (identifier = $id) [start]
-	i, err := strconv.ParseInt(line[len(entry):len(line)-len(") [start]")], 10, 64)
+	// Setting place ID $id
+	i, err := strconv.ParseInt(strings.TrimPrefix(line, entry), 10, 64)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #671

It appears that "open place" no longer appears on the log, however counter-intuitively CloseDataModel prints a similar line which can be used in it's place.