### PR TITLE
Add game icon to Discord RPC

### DIFF
--- a/internal/studiorpc/studiorpc.go
+++ b/internal/studiorpc/studiorpc.go
@@ -97,6 +97,7 @@ func (s *StudioRPC) handleEdit(line string) error {
 		s.place = nil
 		s.presence.Details = "Idling"
 		s.presence.State = ""
+		s.presence.Assets.LargeImage = ""
 		s.presence.Assets.SmallImage = ""
 		s.presence.Timestamps = &drpc.Timestamps{
 			Start: time.Now(),


### PR DESCRIPTION
This adds the game icon to Discord RPC, falling more in line with how Sober does it.