### PR TITLE
Differential Updates

### DIFF
--- a/cmd/vinegar/bootstrapper.go
+++ b/cmd/vinegar/bootstrapper.go
@@ -34,7 +34,6 @@ type bootstrapper struct {
 	status gtk.Label
 	info   gtk.Label
 
-	dir string
 	bin *rbxbin.Deployment
 
 	procs []*os.Process

--- a/cmd/vinegar/bootstrapper_run.go
+++ b/cmd/vinegar/bootstrapper_run.go
@@ -12,11 +12,12 @@ import (
 
 	"github.com/jwijenbergh/puregotk/v4/glib"
 	"github.com/sewnie/wine"
+	"github.com/vinegarhq/vinegar/internal/dirs"
 	"github.com/vinegarhq/vinegar/internal/gutil"
 )
 
 func (b *bootstrapper) command(args ...string) (*wine.Cmd, error) {
-	cmd := b.pfx.Wine(filepath.Join(b.dir, "RobloxStudioBeta.exe"), args...)
+	cmd := b.pfx.Wine(filepath.Join(dirs.Deployment, "RobloxStudioBeta.exe"), args...)
 	if cmd.Err != nil {
 		return nil, cmd.Err
 	}

--- a/cmd/vinegar/bootstrapper_setup.go
+++ b/cmd/vinegar/bootstrapper_setup.go
@@ -71,7 +71,7 @@ func (b *bootstrapper) copyOverlay() error {
 
 	b.message(L("Copying Overlay"))
 
-	return cp.Copy(dir, b.dir)
+	return cp.Copy(dir, dirs.Deployment)
 }
 
 func (b *bootstrapper) preRun() error {
@@ -118,5 +118,5 @@ func (b *bootstrapper) applyFFlags() error {
 	}
 
 	b.message(L("Applying FFlags"))
-	return f.Apply(b.dir)
+	return f.Apply(dirs.Deployment)
 }

--- a/cmd/vinegar/manager.go
+++ b/cmd/vinegar/manager.go
@@ -58,7 +58,7 @@ func (a *app) newManager() *manager {
 
 		"prefix-kill":   m.killPrefix,
 		"delete-prefix": m.deletePrefixes,
-		"delete-studio": m.deleteDeployments,
+		"delete-studio": m.deleteDeployment,
 		"clear-cache":   m.clearCache,
 		"update":        m.updateWine,
 		"restore":       m.boot.restoreSettings,

--- a/cmd/vinegar/manager_actions.go
+++ b/cmd/vinegar/manager_actions.go
@@ -126,8 +126,8 @@ func (m *manager) deletePrefixes() error {
 	return nil
 }
 
-func (m *manager) deleteDeployments() error {
-	if err := os.RemoveAll(dirs.Versions); err != nil {
+func (m *manager) deleteDeployment() error {
+	if err := os.RemoveAll(dirs.Deployment); err != nil {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/jwijenbergh/puregotk v0.0.0-20251201161753-28ec1479c381
 	github.com/lmittmann/tint v1.1.2
 	github.com/pojntfx/go-gettext v0.2.0
-	github.com/sewnie/rbxbin v0.0.0-20251014195941-5c5a3767d780
+	github.com/sewnie/rbxbin v0.0.0-20251228183315-8c321727936e
 	github.com/sewnie/rbxweb v0.0.0-20250923154144-a174c75bba5d
 	github.com/sewnie/wine v0.0.0-20251229152920-167ad5e895fe
 	github.com/ulikunitz/xz v0.5.15

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/sewnie/drpc v0.0.0-20251027131846-60568f62ffb3 h1:6fpbNYIPwHciuuPVr4d
 github.com/sewnie/drpc v0.0.0-20251027131846-60568f62ffb3/go.mod h1:vV4ApNpKIGN4PT5NYmWqw1IEIsFzqj0pspTUSltS+gk=
 github.com/sewnie/rbxbin v0.0.0-20251014195941-5c5a3767d780 h1:O5c9zKWHqOSzLBhJ1sOpIqFRGCHG4t8isYcfiRb5jvQ=
 github.com/sewnie/rbxbin v0.0.0-20251014195941-5c5a3767d780/go.mod h1:Ksjrzt8x1UY2ot2QdDrJXYhTEQOjWH8US0CHgKcH+QY=
+github.com/sewnie/rbxbin v0.0.0-20251228183315-8c321727936e h1:gIVKDHqky9549aoIBK9Un8blizqVlBgZbIX2IgZDpKk=
+github.com/sewnie/rbxbin v0.0.0-20251228183315-8c321727936e/go.mod h1:gXO8Z0B62sjfHzkdl9vCt+DzOaSy97wrSCcVj/LjOpw=
 github.com/sewnie/rbxweb v0.0.0-20250923154144-a174c75bba5d h1:9+O1OzqsVhNJVPewE7oJqVymRlm+ej8iArdafc7vfKs=
 github.com/sewnie/rbxweb v0.0.0-20250923154144-a174c75bba5d/go.mod h1:nSfgVAspLMsixAWAfuTXAjBsiTyMchPxTx+jD3TrM20=
 github.com/sewnie/wine v0.0.0-20251229152920-167ad5e895fe h1:1/FMCQJpEdGnApBTUbUSJRgNYuIpVsX4CgfG/rz4Qw4=

--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -8,14 +8,13 @@ import (
 )
 
 var (
-	Cache     = filepath.Join(xdg.CacheHome, "vinegar")
-	Config    = filepath.Join(xdg.ConfigHome, "vinegar")
-	Data      = filepath.Join(xdg.DataHome, "vinegar")
-	Overlays  = filepath.Join(Config, "overlays")
-	Downloads = filepath.Join(Cache, "downloads")
-	Logs      = filepath.Join(Cache, "logs")
-	Prefixes  = filepath.Join(Data, "prefixes")
-	Versions  = filepath.Join(Data, "versions")
+	Cache      = filepath.Join(xdg.CacheHome, "vinegar")
+	Config     = filepath.Join(xdg.ConfigHome, "vinegar")
+	Data       = filepath.Join(xdg.DataHome, "vinegar")
+	Overlays   = filepath.Join(Config, "overlays")
+	Logs       = filepath.Join(Cache, "logs")
+	Prefixes   = filepath.Join(Data, "prefixes")
+	Deployment = filepath.Join(Data, "deployment")
 )
 
 var (


### PR DESCRIPTION
This PR alters the installation process so that the previous version is preserved and updates are applied on top of it.

This is achieved by first altering the installation path to match the channel's name and by saving the current version GUID and file list inside the newly created `VinegarDeployment.json` inside the version folder.

When it comes time to update Studio's version, the json file is read and files that no longer exist on the newer version are deleted and the new version is extracted on top, overwriting all files.

When combined with [this PR](https://github.com/sewnie/rbxbin/pull/1), only altered files are written to the disc, this minimizes writes to the disk which can reduce wear.