### PR TITLE
Fix Toolbox title bar overlapping WebView

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,8 +153,6 @@ func (c *Config) Prefix() *wine.Prefix {
 		env["WINEDEBUG"] += ",fixme-all,err-kerberos,err-ntlm,err-combase"
 	}
 
-	env["WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS"] = "--in-process-gpu "
-
 	switch c.Studio.Renderer {
 	case "D3D11", "D3D11FL10", "OpenGL":
 		env["WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS"] += "--use-angle=gl"


### PR DESCRIPTION
Effectively reverts https://github.com/vinegarhq/vinegar/commit/306a56065113824330fc4606611943f17349139d and fixes whatever this is.

https://github.com/user-attachments/assets/2b2579bf-dcd5-4ab5-95b9-29dbd1fa5589

This occurs when using Virtual Desktop and I'd rather have WebView temporarily flicker when resizing instead of having the search bar permanently stuck behind the title bar.