### PR TITLE
Switch WebView backend to Vulkan on Vulkan-based renderers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -170,7 +170,6 @@ func (c *Config) Prefix() *wine.Prefix {
 		env["DXVK_LOG_PATH"] = "none"
 		env["DXVK_STATE_CACHE_PATH"] = dirs.Cache
 	}
-	env["VK_LOADER_LAYERS_ENABLE"] = "VK_LAYER_VINEGAR_VinegarLayer"
 
 	for k, v := range env {
 		pfx.Env = append(pfx.Env, k+"="+v)


### PR DESCRIPTION
This PR switches the WebView backend for Vulkan-based renderers from D3D11 to Vulkan. Apparently the reason why it didn't work with Vinegar was because of the VinegarLayer Vulkan layer, the purpose of which was to fix VK_ERROR_OUT_OF_DATE_KHR errors related to the Vulkan renderer on NVIDIA hardware.

Due to the fact that DXVK is now the default renderer and the Vulkan layer not actually fixing the problem in some cases (see the [Discord thread](https://discord.com/channels/1069506340973707304/1446177727022370917/1446177727022370917)), I think it's safe to disable this by default.

I think it should still be kept for the next release incase something goes wrong.