### PR TITLE
Remove native OpenGL renderer from settings

### DIFF
--- a/internal/config/values.go
+++ b/internal/config/values.go
@@ -35,7 +35,7 @@ func (WineOption) SelectPath() {}
 type Renderer string
 
 func (r Renderer) Values() []string {
-	return []string{"D3D11", "DXVK", "DXVK-Sarek", "Vulkan", "D3D11FL10", "OpenGL"}
+	return []string{"D3D11", "D3D11FL10", "DXVK", "DXVK-Sarek", "Vulkan"}
 }
 
 func (r Renderer) IsDXVK() bool {


### PR DESCRIPTION
This PR removes the native OpenGL renderer from Vinegar's settings (see https://bugs.winehq.org/show_bug.cgi?id=59090 for the reason why), making it only accessible through editing the config file directly for testing purposes.

~~It also gets rid of some leftovers from the GPU picker, which was removed in version 1.9.2.~~