### PR TITLE
Update WebView2 and revert disable-gpu-compositing change

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,7 +207,7 @@ func (c *Config) Prefix() *wine.Prefix {
 		env["WINEDEBUG"] += ",fixme-all,err-kerberos,err-ntlm,err-combase"
 	}
 
-	env["WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS"] = "--disable-gpu-compositing "
+	env["WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS"] = "--in-process-gpu "
 
 	switch c.Studio.Renderer {
 	case "D3D11", "D3D11FL10", "OpenGL":

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,8 +16,8 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/sewnie/rbxbin"
 	"github.com/sewnie/wine"
-	"github.com/vinegarhq/vinegar/internal/dirs"
 	"github.com/sewnie/wine/dxvk"
+	"github.com/vinegarhq/vinegar/internal/dirs"
 	"github.com/vinegarhq/vinegar/internal/logging"
 	"github.com/vinegarhq/vinegar/internal/sysinfo"
 )
@@ -25,7 +25,7 @@ import (
 const (
 	DXVKVersion      = "2.7.1"
 	DXVKSarekVersion = "Sarek-1.11.0-async"
-	WebViewVersion   = "144.0.3719.92"
+	WebViewVersion   = "147.0.3912.72"
 
 	DesktopsResolution = "1814x1024"
 )


### PR DESCRIPTION
Functional with the latest stable release of Kombucha.