### PR TITLE
Fix make and CI build with Go 1.25 pidfd handling

### DIFF
--- a/cmd/vinegar/bootstrapper_run.go
+++ b/cmd/vinegar/bootstrapper_run.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -53,6 +54,12 @@ func (b *bootstrapper) command(args ...string) (*wine.Cmd, error) {
 	return cmd, nil
 }
 
+func pidfdStartUnsupported(err error) bool {
+	return errors.Is(err, syscall.EINVAL) ||
+		errors.Is(err, syscall.ENOSYS) ||
+		errors.Is(err, syscall.EPERM)
+}
+
 func (b *bootstrapper) execute(args ...string) error {
 	cmd, err := b.command(args...)
 	if err != nil {
@@ -64,6 +71,28 @@ func (b *bootstrapper) execute(args ...string) error {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(c)
+	pidfd := -1
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.PidFD = &pidfd
+
+	if err := cmd.Start(); err != nil {
+		if !pidfdStartUnsupported(err) {
+			return err
+		}
+
+		slog.Warn("Failed to start with pidfd, retrying without GameMode registration", "err", err)
+		pidfd = -1
+		cmd, err = b.command(args...)
+		if err != nil {
+			return err
+		}
+		if err := cmd.Start(); err != nil {
+			return err
+		}
+	}
+
 	go func() {
 		s := <-c
 		signal.Stop(c)
@@ -77,10 +106,6 @@ func (b *bootstrapper) execute(args ...string) error {
 		}
 	}()
 
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-
 	b.count++
 	defer func() {
 		b.count--
@@ -90,11 +115,12 @@ func (b *bootstrapper) execute(args ...string) error {
 		b.win.SetVisible(false)
 	})
 
-	cmd.Process.WithHandle(func(h uintptr) {
-		if err := b.registerGame(h); err != nil {
+	if pidfd != -1 {
+		if err := b.registerGame(uintptr(pidfd)); err != nil {
 			slog.Error("Failed to register with GameMode", "err", err)
 		}
-	})
+		_ = syscall.Close(pidfd)
+	}
 
 	err = cmd.Wait()
 


### PR DESCRIPTION
## Summary
- Fix the make/CI build failure on Go 1.25 by replacing Process.WithHandle with SysProcAttr.PidFD for the GameMode pidfd path.
- Keep GameMode registration best-effort by retrying the Studio launch without PidFD when the kernel or sandbox rejects pidfd startup.
- Move the signal handler until after a successful Start so fallback command rebuilds cannot race with a nil Process.

## Root cause
The build workflow requests Go >=1.22, while go.mod requires Go 1.25, so CI resolves to Go 1.25.10 before running make. The make build then fails because Process.WithHandle is not available in that toolchain.

## Validation
- GOTOOLCHAIN=go1.25.10 make
- GOTOOLCHAIN=go1.25.10 make vinegar
- GOTOOLCHAIN=go1.25.10 go build ./cmd/vinegar
- go test ./...
- GOTOOLCHAIN=go1.25.10 go test ./...
- git diff --check
- Local code review loop: CodeRabbit, Claude, Codex reviewer, and Grok reported no remaining actionable issues.
