### PR TITLE
cmd/vinegar: also register default handler for place/model URIs and f…

### DIFF
--- a/cmd/vinegar/app.go
+++ b/cmd/vinegar/app.go
@@ -240,6 +240,23 @@ func (a *app) setMime() error {
 	if !ok || err != nil {
 		return fmt.Errorf("browser login set: %w", err)
 	}
+
+	// Also register as the default handler for opening places/models
+	// directly (the roblox-studio: URI scheme, used e.g. by the recent
+	// list on the Studio home screen) and for the associated file
+	// types. Unlike the auth scheme above, failing to register these
+	// is not fatal - Studio can still be launched manually - so we
+	// only warn.
+	for _, t := range []string{
+		"x-scheme-handler/roblox-studio",
+		"application/x-roblox-place",
+		"application/x-roblox-model",
+	} {
+		if ok, err := selfApp.SetAsDefaultForType(t); !ok || err != nil {
+			slog.Warn("Failed to register default handler", "type", t, "err", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Related to #961 (Vinegar fails to open recent list place, while correctly opening recent list home).

setMime() currently only claims default-handler status for the roblox-studio-auth scheme (used for browser login, see #960, fixed in #963). The .desktop file also lists x-scheme-handler/roblox-studio, application/x-roblox-place, and application/x-roblox-model in its MimeType= field, but none of these are ever actually claimed via SetAsDefaultForType() in code - only advertised as capable of handling them, never registered as the default.

This mirrors the exact root cause behind #960: being listed in the .desktop file's MimeType isn't enough on its own (especially under Flatpak's portal-based sandboxing) for the OS to route a request to Vinegar; the app needs to explicitly claim default-handler status.

My hypothesis is that Studio's "recent list" opens a cloud place via a roblox-studio: URI dispatched through the OS, and if Vinegar was never claimed as the default handler for it, the request can silently go nowhere - which would explain why "recent home" (in-app navigation, no OS dispatch involved) works while "recent place" doesn't. I want to be upfront that I have not confirmed Studio actually uses this URI for the recent list specifically - that part is inference, not verified.

I'm on CachyOS (Arch-based, source install), where "recent place" already opens fine without this fix, so I couldn't reproduce or confirm the fix against the actual bug - native installs generally don't need the sandboxed portal claim the way Flatpak does. The #961 reporter is on Flatpak, which is the environment where this gap should actually matter. If a Flatpak user can test this branch and confirm or deny, that would help a lot.

The added registrations are non-fatal (slog.Warn on failure), so this shouldn't regress anything even if the hypothesis turns out to be wrong.