### PR TITLE
internal: Use ANGLE for WebView2

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,13 +215,16 @@ func (c *Config) Prefix() *wine.Prefix {
 		env["WINEDEBUG"] += ",fixme-all,err-kerberos,err-ntlm,err-combase"
 	}
 
-	env["WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS"] = "--disable-gpu"
-
 	switch c.Studio.Renderer {
+	case "D3D11", "D3D11FL10":
+		env["WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS"] = "--use-angle=gl"
+		env["WINE_D3D_CONFIG"] = "renderer=gl"
 	case "DXVK", "DXVK-Sarek":
+		env["WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS"] = "--use-angle=vulkan"
 		env["WINE_D3D_CONFIG"] = "renderer=vulkan"
 	case "Vulkan":
 		env["VK_LOADER_LAYERS_ENABLE"] = "VK_LAYER_VINEGAR_VinegarLayer"
+		env["WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS"] = "--use-angle=vulkan"
 		env["WINE_D3D_CONFIG"] = "renderer=vulkan"
 	}
 


### PR DESCRIPTION
Fixes WebView2 from freezing on certain setups when opening Studio for the first time. The issues with ANGLE's Vulkan backend and the Vulkan layer provided by Vinegar should already be addressed with https://github.com/vinegarhq/kombucha/commit/3c41bd6463c50f20da8c8dbb50865600d50067de.

I also explicitly set WINE_D3D_CONFIG=renderer=gl for both D3D11 and D3D11FL10 renderer options incase Wine ever changes the default backend for WineD3D to Vulkan.

Effectively reverts https://github.com/vinegarhq/vinegar/pull/905.